### PR TITLE
Improve parseUInt64

### DIFF
--- a/cadence/contracts/AddressUtils.cdc
+++ b/cadence/contracts/AddressUtils.cdc
@@ -17,30 +17,32 @@ pub contract AddressUtils {
         return address
     }
     
-    priv fun parseUInt64(_ input: AnyStruct): UInt64?{
-        var stringValue:String = ""
+    priv fun parseUInt64(_ input: AnyStruct): UInt64? {
+        var stringValue = ""
 
-        if input.getType().isSubtype(of: Type<String>()){
-            stringValue = input as! String
-        }
-        else if input.getType().isSubtype(of: Type<Int>()){
-            stringValue = (input as! Int).toString()
-        }
-        else if input.getType().isSubtype(of: Type<Address>()){
-            stringValue = (input as! Address).toString()
-        }
-        else if input.getType().isSubtype(of: Type<Type>()){
-            stringValue =  StringUtils.split((input as! Type).identifier, ".")[1]
+        if let string = input as? String {
+            stringValue = string
+        } else if let number = input as? Number {
+            stringValue = number.toString()
+        } else if let address = input as? Address {
+            stringValue = address.toString()
+        } else if let type = input as? Type {
+            let parts = StringUtils.split(type.identifier, ".")
+            if parts.length == 1 {
+                return nil
+            }
+            stringValue = parts[1]
         }
 
-        var address=self.withoutPrefix(stringValue)
-        var r:UInt64 = 0
+        var address = withoutPrefix(stringValue)
+        var r: UInt64 = 0
         var bytes = address.decodeHex()
-        while bytes.length>0{
-            r = r  + (UInt64(bytes.removeFirst()) << UInt64(bytes.length * 8 ))
+        var length = bytes.length
+        for byte in bytes {
+            length = length - 1
+            r = r + UInt64(byte) << UInt64(length * 8)
         }
         return r
-
     }
 
     pub fun parseAddress(_ input: AnyStruct): Address?{

--- a/cadence/contracts/AddressUtils.cdc
+++ b/cadence/contracts/AddressUtils.cdc
@@ -30,6 +30,9 @@ pub contract AddressUtils {
                 return nil
             }
             stringValue = parts[1]
+        } else {
+            return nil
+        }
         }
 
         var address = withoutPrefix(stringValue)

--- a/cadence/contracts/AddressUtils.cdc
+++ b/cadence/contracts/AddressUtils.cdc
@@ -22,8 +22,6 @@ pub contract AddressUtils {
 
         if let string = input as? String {
             stringValue = string
-        } else if let number = input as? Number {
-            stringValue = number.toString()
         } else if let address = input as? Address {
             stringValue = address.toString()
         } else if let type = input as? Type {


### PR DESCRIPTION
- Use failable casting instead of unnecessary run-time type construction and subtype checking
- Conversion of `Int` was wrong: The integer is converted to decimal, then parsed as hex
- Conversion of `Type` didn't handle cases where the type is not deployed to an account, e.g. built-in types
- Optimize the byte array conversion: Instead of mutating the byte array, just look up the byte