### PR TITLE
Add tests for `StringUtils` & `AddressUtils` contracts

### DIFF
--- a/cadence/contracts/AddressUtils.cdc
+++ b/cadence/contracts/AddressUtils.cdc
@@ -1,23 +1,23 @@
-import StringUtils from "./StringUtils.cdc"
+import StringUtils from "StringUtils"
 
 pub contract AddressUtils {
 
-    priv fun withoutPrefix(_ input: String): String{
-        var address=input
+    pub fun withoutPrefix(_ input: String): String {
+        var address = input
 
-        //get rid of 0x
-        if address.length>1 && address.utf8[1] == 120 {
+        // get rid of 0x
+        if address.length > 1 && address.utf8[1] == 120 {
             address = address.slice(from: 2, upTo: address.length)
         }
 
-        //ensure even length
-        if address.length%2==1{
-            address="0".concat(address)
+        // ensure even length
+        if address.length % 2 == 1 {
+            address = "0".concat(address)
         }
         return address
     }
-    
-    priv fun parseUInt64(_ input: AnyStruct): UInt64? {
+
+    pub fun parseUInt64(_ input: AnyStruct): UInt64? {
         var stringValue = ""
 
         if let string = input as? String {
@@ -33,66 +33,64 @@ pub contract AddressUtils {
         } else {
             return nil
         }
-        }
 
-        var address = withoutPrefix(stringValue)
+        let address = self.withoutPrefix(stringValue)
+        let bytes = address.decodeHex()
         var r: UInt64 = 0
-        var bytes = address.decodeHex()
         var length = bytes.length
         for byte in bytes {
             length = length - 1
-            r = r + UInt64(byte) << UInt64(length * 8)
+            r = r + (UInt64(byte) << UInt64(length * 8))
         }
         return r
     }
 
-    pub fun parseAddress(_ input: AnyStruct): Address?{
-        if let parsed = self.parseUInt64(input){
+    pub fun parseAddress(_ input: AnyStruct): Address? {
+        if let parsed = self.parseUInt64(input) {
             return Address(parsed)
         }
         return nil
     }
 
-    pub fun isValidAddress(_ input: AnyStruct, forNetwork: String) : Bool{
-        
-        if let address = self.parseUInt64(input) {
-            
-            var codeWords: {String:UInt64} = {
-                "MAINNET" : 0,
-                "TESTNET" : 0x6834ba37b3980209,
-                "EMULATOR": 0x1cb159857af02018
-            }
-
-            var parityCheckMatrixColumns: [UInt64] = [
-                0x00001, 0x00002, 0x00004, 0x00008, 0x00010, 0x00020, 0x00040, 0x00080,
-                0x00100, 0x00200, 0x00400, 0x00800, 0x01000, 0x02000, 0x04000, 0x08000,
-                0x10000, 0x20000, 0x40000, 0x7328d, 0x6689a, 0x6112f, 0x6084b, 0x433fd,
-                0x42aab, 0x41951, 0x233ce, 0x22a81, 0x21948, 0x1ef60, 0x1deca, 0x1c639,
-                0x1bdd8, 0x1a535, 0x194ac, 0x18c46, 0x1632b, 0x1529b, 0x14a43, 0x13184,
-                0x12942, 0x118c1, 0x0f812, 0x0e027, 0x0d00e, 0x0c83c, 0x0b01d, 0x0a831,
-                0x0982b, 0x07034, 0x0682a, 0x05819, 0x03807, 0x007d2, 0x00727, 0x0068e,
-                0x0067c, 0x0059d, 0x004eb, 0x003b4, 0x0036a, 0x002d9, 0x001c7, 0x0003f
-            ]
-
-            var parity: UInt64 = 0
-            var codeWord: UInt64 = codeWords[forNetwork]! //0 for mainnet
-            codeWord = codeWord ^ address
-
-            if codeWord==0{
-                return false
-            }
-
-            for column in parityCheckMatrixColumns{
-                if codeWord & 1 == 1{
-                    parity = parity ^ column
-                }
-                codeWord = codeWord >> 1
-            }
-
-            return parity==0 && codeWord==0
-
+    pub fun isValidAddress(_ input: AnyStruct, forNetwork: String): Bool {
+        let address = self.parseUInt64(input)
+        if address == nil {
+            return false
         }
-        return false
+
+        let codeWords: {String: UInt64} = {
+            "MAINNET" : 0,
+            "TESTNET" : 0x6834ba37b3980209,
+            "EMULATOR": 0x1cb159857af02018
+        }
+
+        let parityCheckMatrixColumns: [UInt64] = [
+            0x00001, 0x00002, 0x00004, 0x00008, 0x00010, 0x00020, 0x00040, 0x00080,
+            0x00100, 0x00200, 0x00400, 0x00800, 0x01000, 0x02000, 0x04000, 0x08000,
+            0x10000, 0x20000, 0x40000, 0x7328d, 0x6689a, 0x6112f, 0x6084b, 0x433fd,
+            0x42aab, 0x41951, 0x233ce, 0x22a81, 0x21948, 0x1ef60, 0x1deca, 0x1c639,
+            0x1bdd8, 0x1a535, 0x194ac, 0x18c46, 0x1632b, 0x1529b, 0x14a43, 0x13184,
+            0x12942, 0x118c1, 0x0f812, 0x0e027, 0x0d00e, 0x0c83c, 0x0b01d, 0x0a831,
+            0x0982b, 0x07034, 0x0682a, 0x05819, 0x03807, 0x007d2, 0x00727, 0x0068e,
+            0x0067c, 0x0059d, 0x004eb, 0x003b4, 0x0036a, 0x002d9, 0x001c7, 0x0003f
+        ]
+
+        var parity: UInt64 = 0
+        var codeWord: UInt64 = codeWords[forNetwork]!
+        codeWord = codeWord ^ address!
+
+        if codeWord == 0 {
+            return false
+        }
+
+        for column in parityCheckMatrixColumns{
+            if codeWord & 1 == 1 {
+                parity = parity ^ column
+            }
+            codeWord = codeWord >> 1
+        }
+
+        return parity == 0 && codeWord == 0
     }
 
     pub fun getNetworkFromAddress(_ input: AnyStruct): String? {
@@ -104,9 +102,8 @@ pub contract AddressUtils {
         return nil
     }
 
-    pub fun currentNetwork(): String{
+    pub fun currentNetwork(): String {
         return self.getNetworkFromAddress(self.account.address)!
     }
 
 }
- 

--- a/cadence/contracts/StringUtils.cdc
+++ b/cadence/contracts/StringUtils.cdc
@@ -1,4 +1,4 @@
-import ArrayUtils from "./ArrayUtils.cdc"
+import ArrayUtils from "ArrayUtils"
 
 pub contract StringUtils {
    

--- a/cadence/scripts/address_utils_get_current_network.cdc
+++ b/cadence/scripts/address_utils_get_current_network.cdc
@@ -1,0 +1,11 @@
+import AddressUtils from "../contracts/AddressUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var network = AddressUtils.currentNetwork()
+
+    // Assert
+    assert(network == "EMULATOR")
+
+    return true
+}

--- a/cadence/scripts/address_utils_get_network_from_address.cdc
+++ b/cadence/scripts/address_utils_get_network_from_address.cdc
@@ -1,0 +1,11 @@
+import AddressUtils from "../contracts/AddressUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    let network = AddressUtils.getNetworkFromAddress(1541)
+
+    // Assert
+    assert(network == nil)
+
+    return true
+}

--- a/cadence/scripts/address_utils_is_valid_address.cdc
+++ b/cadence/scripts/address_utils_is_valid_address.cdc
@@ -1,0 +1,26 @@
+import AddressUtils from "../contracts/AddressUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    let mainnet = AddressUtils.isValidAddress("0xa340dc0a4ec828ab", forNetwork: "MAINNET")
+    let testnet = AddressUtils.isValidAddress("0x31ad40c07a2a9788", forNetwork: "TESTNET")
+    let emulator = AddressUtils.isValidAddress("0xf8d6e0586b0a20c7", forNetwork: "EMULATOR")
+
+    // Assert
+    assert(mainnet && testnet && emulator)
+
+    // Act
+    var valid = AddressUtils.isValidAddress(1452, forNetwork: "EMULATOR")
+
+    // Assert
+    assert(valid == false)
+
+    // Act
+    valid = AddressUtils.isValidAddress("0x6834ba37b3980209", forNetwork: "TESTNET")
+
+    // Assert
+    assert(valid == false)
+
+
+    return true
+}

--- a/cadence/scripts/address_utils_parse_address.cdc
+++ b/cadence/scripts/address_utils_parse_address.cdc
@@ -1,0 +1,17 @@
+import AddressUtils from "../contracts/AddressUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = AddressUtils.parseAddress("0xf8d6e0586b0a20c7")
+
+    // Assert
+    assert(value! == Address(0xf8d6e0586b0a20c7))
+
+    // Act
+    value = AddressUtils.parseAddress(1005)
+
+    // Assert
+    assert(value == nil)
+
+    return true
+}

--- a/cadence/scripts/address_utils_parse_uint64.cdc
+++ b/cadence/scripts/address_utils_parse_uint64.cdc
@@ -1,0 +1,36 @@
+import FlowToken from 0x0ae53cb6e3f42a79
+import AddressUtils from "../contracts/AddressUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = AddressUtils.parseUInt64("0xf8d6e0586b0a20c7")
+
+    // Assert
+    assert(value == 17930765636779778247)
+
+    // Act
+    value = AddressUtils.parseUInt64(Address(0xf8d6e0586b0a20c7))
+
+    // Assert
+    assert(value == 17930765636779778247)
+
+    // Act
+    value = AddressUtils.parseUInt64(FlowToken.getType())
+
+    // Assert
+    assert(value == 785100466252163705)
+
+    // Act
+    value = AddressUtils.parseUInt64(0x01)
+
+    // Assert
+    assert(value == nil)
+
+    // Act
+    value = AddressUtils.parseUInt64("hello".getType())
+
+    // Assert
+    assert(value == nil)
+
+    return true
+}

--- a/cadence/scripts/address_utils_without_prefix.cdc
+++ b/cadence/scripts/address_utils_without_prefix.cdc
@@ -1,0 +1,18 @@
+import AddressUtils from "../contracts/AddressUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = AddressUtils.withoutPrefix("0xf8d6e0586b0a20c7")
+
+    // Assert
+    assert(value == "f8d6e0586b0a20c7")
+
+    // Act
+    // Odd length
+    value = AddressUtils.withoutPrefix("8d6e0586b0a20c7")
+
+    // Assert
+    assert(value == "08d6e0586b0a20c7")
+
+    return true
+}

--- a/cadence/scripts/string_utils_contains.cdc
+++ b/cadence/scripts/string_utils_contains.cdc
@@ -1,0 +1,17 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.contains("Hello, World!", "orl")
+
+    // Assert
+    assert(value)
+
+    // Act
+    value = StringUtils.contains("Hello, World!", "wow")
+
+    // Assert
+    assert(value == false)
+
+    return true
+}

--- a/cadence/scripts/string_utils_count.cdc
+++ b/cadence/scripts/string_utils_count.cdc
@@ -1,0 +1,11 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.count("Hello, World!", "o")
+
+    // Assert
+    assert(value == 2)
+
+    return true
+}

--- a/cadence/scripts/string_utils_explode.cdc
+++ b/cadence/scripts/string_utils_explode.cdc
@@ -1,0 +1,14 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.explode("Hello!")
+
+    // Assert
+    var expected = ["H", "e", "l", "l", "o", "!"]
+    for char in expected {
+        assert(value.contains(char))
+    }
+
+    return true
+}

--- a/cadence/scripts/string_utils_format.cdc
+++ b/cadence/scripts/string_utils_format.cdc
@@ -1,0 +1,11 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.format("Hello, {name}!", {"name": "Peter"})
+
+    // Assert
+    assert(value == "Hello, Peter!")
+
+    return true
+}

--- a/cadence/scripts/string_utils_has_prefix.cdc
+++ b/cadence/scripts/string_utils_has_prefix.cdc
@@ -1,0 +1,17 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.hasPrefix("Hello, World!", "Hell")
+
+    // Assert
+    assert(value)
+
+    // Act
+    value = StringUtils.hasPrefix("Hell", "Hello, World!")
+
+    // Assert
+    assert(value == false)
+
+    return true
+}

--- a/cadence/scripts/string_utils_has_suffix.cdc
+++ b/cadence/scripts/string_utils_has_suffix.cdc
@@ -1,0 +1,17 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.hasSuffix("Hello, World!", "ld!")
+
+    // Assert
+    assert(value)
+
+    // Act
+    value = StringUtils.hasSuffix("ld!", "Hello, World!")
+
+    // Assert
+    assert(value == false)
+
+    return true
+}

--- a/cadence/scripts/string_utils_index.cdc
+++ b/cadence/scripts/string_utils_index.cdc
@@ -1,0 +1,17 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.index("Hello, Peter!", "Peter", 0)
+
+    // Assert
+    assert(value == 7)
+
+    // Act
+    value = StringUtils.index("Hello, Peter!", "Mark", 0)
+
+    // Assert
+    assert(value == nil)
+
+    return true
+}

--- a/cadence/scripts/string_utils_join.cdc
+++ b/cadence/scripts/string_utils_join.cdc
@@ -1,0 +1,11 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.join(["Hello", "How", "Are", "You", "Today?"], " ")
+
+    // Assert
+    assert(value == "Hello How Are You Today?")
+
+    return true
+}

--- a/cadence/scripts/string_utils_replace_all.cdc
+++ b/cadence/scripts/string_utils_replace_all.cdc
@@ -1,0 +1,11 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.replaceAll("Hello, World!", "l", "L")
+
+    // Assert
+    assert(value == "HeLLo, WorLd!")
+
+    return true
+}

--- a/cadence/scripts/string_utils_split.cdc
+++ b/cadence/scripts/string_utils_split.cdc
@@ -1,0 +1,14 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.split("Hello,How,Are,You? Today", ",")
+
+    // Assert
+    var expected = ["Hello", "How", "Are", "You? Today"]
+    for e in expected {
+        assert(value.contains(e))
+    }
+
+    return true
+}

--- a/cadence/scripts/string_utils_substring_until.cdc
+++ b/cadence/scripts/string_utils_substring_until.cdc
@@ -1,0 +1,17 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.substringUntil("Hello, sir. How are you today?", ".", 0)
+
+    // Assert
+    assert(value == "Hello, sir")
+
+    // Act
+    value = StringUtils.substringUntil("Hello, sir!", ".", 0)
+
+    // Assert
+    assert(value == "Hello, sir!")
+
+    return true
+}

--- a/cadence/scripts/string_utils_trim.cdc
+++ b/cadence/scripts/string_utils_trim.cdc
@@ -1,0 +1,11 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.trim("  Hello, World!")
+
+    // Assert
+    assert(value == "Hello, World!")
+
+    return true
+}

--- a/cadence/scripts/string_utils_trim_left.cdc
+++ b/cadence/scripts/string_utils_trim_left.cdc
@@ -1,0 +1,17 @@
+import StringUtils from "../contracts/StringUtils.cdc"
+
+pub fun main(): Bool {
+    // Act
+    var value = StringUtils.trimLeft("    Hello, World!")
+
+    // Assert
+    assert(value == "Hello, World!")
+
+    // Act
+    value = StringUtils.trimLeft("")
+
+    // Assert
+    assert(value == "")
+
+    return true
+}

--- a/test/AddressUtils_test.cdc
+++ b/test/AddressUtils_test.cdc
@@ -1,0 +1,79 @@
+import Test
+
+pub let blockchain = Test.newEmulatorBlockchain()
+pub let account = blockchain.createAccount()
+
+pub fun setup() {
+    blockchain.useConfiguration(Test.Configuration({
+        "ArrayUtils": account.address,
+        "StringUtils": account.address,
+        "../contracts/AddressUtils.cdc": account.address
+    }))
+
+    let arrayUtils = Test.readFile("../cadence/contracts/ArrayUtils.cdc")
+    var err = blockchain.deployContract(
+        name: "ArrayUtils",
+        code: arrayUtils,
+        account: account,
+        arguments: []
+    )
+
+    let stringUtils = Test.readFile("../cadence/contracts/StringUtils.cdc")
+    err = blockchain.deployContract(
+        name: "StringUtils",
+        code: stringUtils,
+        account: account,
+        arguments: []
+    )
+
+    Test.assert(err == nil)
+
+    let addressUtils = Test.readFile("../cadence/contracts/AddressUtils.cdc")
+    err = blockchain.deployContract(
+        name: "AddressUtils",
+        code: addressUtils,
+        account: account,
+        arguments: []
+    )
+
+    Test.assert(err == nil)
+}
+
+pub fun testWithoutPrefix() {
+    let returnedValue = executeScript("../cadence/scripts/address_utils_without_prefix.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testParseUInt64() {
+    let returnedValue = executeScript("../cadence/scripts/address_utils_parse_uint64.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testParseAddress() {
+    let returnedValue = executeScript("../cadence/scripts/address_utils_parse_address.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testIsValidAddress() {
+    let returnedValue = executeScript("../cadence/scripts/address_utils_is_valid_address.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testGetNetworkFromAddress() {
+    let returnedValue = executeScript("../cadence/scripts/address_utils_get_network_from_address.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testGetCurrentNetwork() {
+    let returnedValue = executeScript("../cadence/scripts/address_utils_get_current_network.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+priv fun executeScript(_ scriptPath: String): Bool {
+    var script = Test.readFile(scriptPath)
+    let value = blockchain.executeScript(script, [])
+
+    Test.assert(value.status == Test.ResultStatus.succeeded)
+
+    return value.returnValue! as! Bool
+}

--- a/test/AddressUtils_test.cdc
+++ b/test/AddressUtils_test.cdc
@@ -18,6 +18,8 @@ pub fun setup() {
         arguments: []
     )
 
+    Test.expect(err, Test.beNil())
+
     let stringUtils = Test.readFile("../cadence/contracts/StringUtils.cdc")
     err = blockchain.deployContract(
         name: "StringUtils",
@@ -26,7 +28,7 @@ pub fun setup() {
         arguments: []
     )
 
-    Test.assert(err == nil)
+    Test.expect(err, Test.beNil())
 
     let addressUtils = Test.readFile("../cadence/contracts/AddressUtils.cdc")
     err = blockchain.deployContract(
@@ -36,44 +38,44 @@ pub fun setup() {
         arguments: []
     )
 
-    Test.assert(err == nil)
+    Test.expect(err, Test.beNil())
 }
 
 pub fun testWithoutPrefix() {
-    let returnedValue = executeScript("../cadence/scripts/address_utils_without_prefix.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/address_utils_without_prefix.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testParseUInt64() {
-    let returnedValue = executeScript("../cadence/scripts/address_utils_parse_uint64.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/address_utils_parse_uint64.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testParseAddress() {
-    let returnedValue = executeScript("../cadence/scripts/address_utils_parse_address.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/address_utils_parse_address.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testIsValidAddress() {
-    let returnedValue = executeScript("../cadence/scripts/address_utils_is_valid_address.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/address_utils_is_valid_address.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testGetNetworkFromAddress() {
-    let returnedValue = executeScript("../cadence/scripts/address_utils_get_network_from_address.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/address_utils_get_network_from_address.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testGetCurrentNetwork() {
-    let returnedValue = executeScript("../cadence/scripts/address_utils_get_current_network.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/address_utils_get_current_network.cdc")
+    Test.assertEqual(true, value)
 }
 
 priv fun executeScript(_ scriptPath: String): Bool {
-    var script = Test.readFile(scriptPath)
+    let script = Test.readFile(scriptPath)
     let value = blockchain.executeScript(script, [])
 
-    Test.assert(value.status == Test.ResultStatus.succeeded)
+    Test.expect(value, Test.beSucceeded())
 
     return value.returnValue! as! Bool
 }

--- a/test/ArrayUtils_test.cdc
+++ b/test/ArrayUtils_test.cdc
@@ -1,42 +1,38 @@
 import Test
-import ArrayUtils from "../cadence/contracts/ArrayUtils.cdc"
+import ArrayUtils from "ArrayUtils"
 
 pub struct Token {
     pub let id: Int
-    pub(set) var balance: Int
+    pub var balance: Int
 
     init(id: Int, balance: Int) {
         self.id = id
         self.balance = balance
     }
+
+    pub fun setBalance(_ balance: Int) {
+        self.balance = balance
+    }
 }
 
-pub(set) var arrayUtils = ArrayUtils()
+pub let arrayUtils = ArrayUtils()
 
 pub fun testRange() {
     // Act
-    var range = arrayUtils.range(0, 10)
+    let range = arrayUtils.range(0, 10)
 
     // Assert
-    var expected: [Int] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    var i: Int = 0
-    while i < expected.length {
-        Test.assert(expected[i] == range[i])
-        i = i + 1
-    }
+    let expected: [Int] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    Test.assertEqual(expected, range)
 }
 
 pub fun testReverseRange() {
     // Act
-    var range = arrayUtils.reverse(arrayUtils.range(0, 10))
+    let range = arrayUtils.reverse(arrayUtils.range(0, 10))
 
     // Assert
-    var expected: [Int] = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-    var i: Int = 0
-    while i < expected.length {
-        Test.assert(expected[i] == range[i])
-        i = i + 1
-    }
+    let expected: [Int] = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    Test.assertEqual(expected, range)
 }
 
 pub fun testTransform() {
@@ -50,14 +46,17 @@ pub fun testTransform() {
     // Act
     arrayUtils.transform(&tokens as &[AnyStruct], fun (t: AnyStruct): AnyStruct {
         var token = t as! Token
-        token.balance = token.balance * 2
+        token.setBalance(token.balance * 2)
         return token
     })
 
     // Assert
-    Test.assert(tokens[0].balance == 20)
-    Test.assert(tokens[1].balance == 10)
-    Test.assert(tokens[2].balance == 30)
+    let expected = [
+        Token(id: 0, balance: 20),
+        Token(id: 1, balance: 10),
+        Token(id: 2, balance: 30)
+    ]
+    Test.assertEqual(expected, tokens)
 }
 
 pub fun testIterate() {
@@ -71,10 +70,17 @@ pub fun testIterate() {
     ]
 
     // Act
-    arrayUtils.iterate(tokens as [AnyStruct], fun (t: AnyStruct): Bool {
+    var totalBalance = 0
+    arrayUtils.iterate(tokens, fun (t: AnyStruct): Bool {
         var token = t as! Token
-        return token.id <= 2
+        if token.id <= 2 {
+            totalBalance = totalBalance + token.balance
+            return true
+        }
+        return false
     })
+
+    Test.assertEqual(30, totalBalance)
 }
 
 pub fun testMap() {
@@ -86,16 +92,19 @@ pub fun testMap() {
     ]
 
     // Act
-    let mapped = arrayUtils.map(tokens as [AnyStruct], fun (t: AnyStruct): AnyStruct {
+    let mapped = arrayUtils.map(tokens, fun (t: AnyStruct): AnyStruct {
         var token = t as! Token
-        token.balance = token.balance - 2
+        token.setBalance(token.balance - 2)
         return token
     })
 
     // Assert
-    Test.assert((mapped[0] as! Token).balance == 8)
-    Test.assert((mapped[1] as! Token).balance == 3)
-    Test.assert((mapped[2] as! Token).balance == 13)
+    let expected: [AnyStruct] = [
+        Token(id: 0, balance: 8),
+        Token(id: 1, balance: 3),
+        Token(id: 2, balance: 13)
+    ]
+    Test.assertEqual(expected, mapped)
 }
 
 pub fun testMapStrings() {
@@ -108,9 +117,12 @@ pub fun testMapStrings() {
     })
 
     // Assert
-    Test.assert(mapped[0] == "Hello, Peter!")
-    Test.assert(mapped[1] == "Hello, John!")
-    Test.assert(mapped[2] == "Hello, Mark!")
+    let expected = [
+        "Hello, Peter!",
+        "Hello, John!",
+        "Hello, Mark!"
+    ]
+    Test.assertEqual(expected, mapped)
 }
 
 pub fun testReduce() {
@@ -120,16 +132,16 @@ pub fun testReduce() {
         Token(id: 1, balance: 5),
         Token(id: 2, balance: 15)
     ]
-    let initial = Token(id: 5, balance: 0) as AnyStruct
+    let initial = Token(id: 5, balance: 0)
 
     // Act
-    let token = arrayUtils.reduce(tokens as [AnyStruct], initial, fun (acc: AnyStruct, t: AnyStruct): AnyStruct {
+    let token = arrayUtils.reduce(tokens, initial, fun (acc: AnyStruct, t: AnyStruct): AnyStruct {
         var token = t as! Token
         var accToken = acc as! Token
-        accToken.balance = accToken.balance + token.balance
+        accToken.setBalance(accToken.balance + token.balance)
         return accToken
     })
 
     // Assert
-    Test.assert((token as! Token).balance == 30)
+    Test.assertEqual(30, (token as! Token).balance)
 }

--- a/test/StringUtils_test.cdc
+++ b/test/StringUtils_test.cdc
@@ -1,0 +1,105 @@
+import Test
+
+pub let blockchain = Test.newEmulatorBlockchain()
+pub let account = blockchain.createAccount()
+
+pub fun setup() {
+    blockchain.useConfiguration(Test.Configuration({
+        "ArrayUtils": account.address,
+        "../contracts/StringUtils.cdc": account.address
+    }))
+
+    let arrayUtils = Test.readFile("../cadence/contracts/ArrayUtils.cdc")
+    var err = blockchain.deployContract(
+        name: "ArrayUtils",
+        code: arrayUtils,
+        account: account,
+        arguments: []
+    )
+
+    Test.assert(err == nil)
+
+    let stringUtils = Test.readFile("../cadence/contracts/StringUtils.cdc")
+    err = blockchain.deployContract(
+        name: "StringUtils",
+        code: stringUtils,
+        account: account,
+        arguments: []
+    )
+
+    Test.assert(err == nil)
+}
+
+pub fun testFormat() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_format.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testExplode() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_explode.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testTrimLeft() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_trim_left.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testTrim() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_trim.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testReplaceAll() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_replace_all.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testHasPrefix() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_has_prefix.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testHasSuffix() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_has_suffix.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testIndex() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_index.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testCount() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_count.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testContains() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_contains.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testSubstringUntil() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_substring_until.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testSplit() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_split.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+pub fun testJoin() {
+    let returnedValue = executeScript("../cadence/scripts/string_utils_join.cdc")
+    Test.assert(returnedValue, message: "found: false")
+}
+
+priv fun executeScript(_ scriptPath: String): Bool {
+    var script = Test.readFile(scriptPath)
+    let value = blockchain.executeScript(script, [])
+
+    Test.assert(value.status == Test.ResultStatus.succeeded)
+
+    return value.returnValue! as! Bool
+}

--- a/test/StringUtils_test.cdc
+++ b/test/StringUtils_test.cdc
@@ -17,7 +17,7 @@ pub fun setup() {
         arguments: []
     )
 
-    Test.assert(err == nil)
+    Test.expect(err, Test.beNil())
 
     let stringUtils = Test.readFile("../cadence/contracts/StringUtils.cdc")
     err = blockchain.deployContract(
@@ -27,79 +27,79 @@ pub fun setup() {
         arguments: []
     )
 
-    Test.assert(err == nil)
+    Test.expect(err, Test.beNil())
 }
 
 pub fun testFormat() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_format.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_format.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testExplode() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_explode.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_explode.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testTrimLeft() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_trim_left.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_trim_left.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testTrim() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_trim.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_trim.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testReplaceAll() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_replace_all.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_replace_all.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testHasPrefix() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_has_prefix.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_has_prefix.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testHasSuffix() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_has_suffix.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_has_suffix.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testIndex() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_index.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_index.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testCount() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_count.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_count.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testContains() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_contains.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_contains.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testSubstringUntil() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_substring_until.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_substring_until.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testSplit() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_split.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_split.cdc")
+    Test.assertEqual(true, value)
 }
 
 pub fun testJoin() {
-    let returnedValue = executeScript("../cadence/scripts/string_utils_join.cdc")
-    Test.assert(returnedValue, message: "found: false")
+    let value = executeScript("../cadence/scripts/string_utils_join.cdc")
+    Test.assertEqual(true, value)
 }
 
 priv fun executeScript(_ scriptPath: String): Bool {
-    var script = Test.readFile(scriptPath)
+    let script = Test.readFile(scriptPath)
     let value = blockchain.executeScript(script, [])
 
-    Test.assert(value.status == Test.ResultStatus.succeeded)
+    Test.expect(value, Test.beSucceeded())
 
     return value.returnValue! as! Bool
 }


### PR DESCRIPTION
Now, all `ArrayUtils` / `StringUtils` / `AddressUtils` contracts, have tests written with the Cadence testing framework:

```bash
flow test --cover test/*_test.cdc

Test results: "test/StringUtils_test.cdc"
- PASS: testFormat
- PASS: testExplode
- PASS: testTrimLeft
- PASS: testTrim
- PASS: testReplaceAll
- PASS: testHasPrefix
- PASS: testHasSuffix
- PASS: testIndex
- PASS: testCount
- PASS: testContains
- PASS: testSubstringUntil
- PASS: testSplit
- PASS: testJoin
Test results: "test/AddressUtils_test.cdc"
- PASS: testWithoutPrefix
- PASS: testParseUInt64
- PASS: testParseAddress
- PASS: testIsValidAddress
- PASS: testGetNetworkFromAddress
- PASS: testGetCurrentNetwork
Test results: "test/ArrayUtils_test.cdc"
- PASS: testRange
- PASS: testReverseRange
- PASS: testTransform
- PASS: testIterate
- PASS: testMap
- PASS: testMapStrings
- PASS: testReduce
Coverage: 91.7% of statements
```

Note that the coverage for the `StringUtils` contract is the following:

```json
"A.01cf0e2f2f715450.StringUtils": {
  "line_hits": {
      ...
  },
  "missed_lines": [],
  "statements": 41,
  "percentage": "100.0%"
}
```

And the coverage for the `AddressUtils` contract is the following:

```json
"A.01cf0e2f2f715450.AddressUtils": {
  "line_hits": {
      ...
  },
  "missed_lines": [],
  "statements": 48,
  "percentage": "100.0%"
}
```
It can be viewed in more details, in the `coverage.json` auto-generated file.

**Note:** The latest `flow-cli` version is required:
```bash
$flow version

Version: v1.3.1
Commit: 9f622977c3dff5381dbaf49fa7984805e34649d3
```